### PR TITLE
DATACASS-201

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -26,6 +26,7 @@ import org.springframework.cassandra.core.cql.CqlIdentifier;
 import org.springframework.data.cassandra.convert.CassandraConverter;
 
 import com.datastax.driver.core.querybuilder.Select;
+import com.datastax.driver.core.querybuilder.Update;
 
 /**
  * Operations for interacting with Cassandra. These operations are used by the Repository implementation, but can also

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -280,7 +280,40 @@ public interface CassandraOperations extends CqlOperations {
 	 * @return The entities given.
 	 */
 	<T> List<T> update(List<T> entities, WriteOptions options);
-
+	/**
+	 * Execute the Update Query and convert to the list of entities
+	 * 
+	 * @param Update must not be {@literal null}.
+	 * @param type must not be {@literal null}, mapped entity type.
+	 * @return
+	 */
+	<T> List<T> update(Update update, Class<T> type);
+	/**
+	 * Execute the Update Query and convert to the list of entities
+	 * 
+	 * @param Update must not be {@literal null}.
+	 * @param type must not be {@literal null}, mapped entity type.
+	 * @param options The {@link WriteOptions} to use.
+	 * @return
+	 */
+	<T> List<T> update(Update update, Class<T> type, WriteOptions options);
+	/**
+	 * Execute the Update Query list and convert to the list of entities
+	 * 
+	 * @param Update must not be {@literal null}.
+	 * @param type must not be {@literal null}, mapped entity type.
+	 * @return
+	 */
+	<T> List<T> update(List<Update> updateList, Class<T> type);
+	/**
+	 * Execute the Update Query list and convert to the list of entities
+	 * 
+	 * @param Update must not be {@literal null}.
+	 * @param type must not be {@literal null}, mapped entity type.
+	 * @param options The {@link WriteOptions} to use.
+	 * @return
+	 */
+	<T> List<T> update(List<Update> updateList, Class<T> type, WriteOptions options);
 	/**
 	 * Updates the given entity asynchronously.
 	 * 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -1037,4 +1037,71 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 		throw new IllegalArgumentException(String.format("Expected type String or Select; got type [%s] with value [%s]",
 				query.getClass(), query));
 	}
+	
+	@Override
+	public <T> List<T> update(Update update, Class<T> type) {
+		return update(update, type,null);
+	}
+
+	@Override
+	public <T> List<T> update(Update update, Class<T> type, WriteOptions options) {
+		Assert.notNull(update);
+		update = CqlTemplate.addWriteOptions(update, options);
+
+		ResultSet resultSet = doExecute(update);
+		if (resultSet == null) {
+			return null;
+		}
+
+		List<T> result = new ArrayList<T>();
+		Iterator<Row> iterator = resultSet.iterator();
+		CassandraConverterRowCallback<T> readRowCallback = new CassandraConverterRowCallback<T>(cassandraConverter, type);
+		while (iterator.hasNext()) {
+			Row row = iterator.next();
+			result.add(readRowCallback.doWith(row));
+		}
+
+		return result;
+	}
+
+	@Override
+	public <T> List<T> update(List<Update> updateList, Class<T> type) {
+		return update(updateList, type,null);
+	}
+
+	@Override
+	public <T> List<T> update(List<Update> updateList, Class<T> type, WriteOptions options) {
+		return doBatchUpdate(updateList, options, type);
+	}
+	
+	protected <T> List<T> doBatchUpdate(List<Update> updateList, WriteOptions options, Class<T> type) {
+
+		if (updateList == null || updateList.size() == 0) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("no-op due to given null or empty list");
+			}
+			return null;
+		}
+
+		Batch b = QueryBuilder.batch();
+		for (Update update : updateList) {
+			b.add(update);
+		}
+
+		CqlTemplate.addQueryOptions(b, options);
+		ResultSet resultSet = doExecute(b);
+		if (resultSet == null) {
+			return null;
+		}
+
+		List<T> result = new ArrayList<T>();
+		Iterator<Row> iterator = resultSet.iterator();
+		CassandraConverterRowCallback<T> readRowCallback = new CassandraConverterRowCallback<T>(cassandraConverter, type);
+		while (iterator.hasNext()) {
+			Row row = iterator.next();
+			result.add(readRowCallback.doWith(row));
+		}
+
+		return result;
+	}
 }


### PR DESCRIPTION
Currently the API does not allow to update collections inside the tables.
It only allows add,remove and replace operations over collections.
Expose com.datastax.driver.core.querbuilder.Update from CassandraOperations and use it to update existing collections in the tables.
Expose com.datastax.driver.core.querbuilder.Update from CassandraOperations.
<T> List<T> update(Update update, Class<T> type); and other similar functions.

I will be adding Unit Tests to it soon
